### PR TITLE
Fix typos and parsing bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ version = "0.1.12"
 description = "Dataloaders for training models on huge single-cell datasets"
 readme = "README.md"
 authors = [
-    { name = "Abhinav Adduri", email = "abhinav.adduri@arcinsistute.org" },
-    { name = "Yusuf Roohani", email = "yusuf.roohani@arcinsistute.org" },
-    { name = "Noam Teyssier", email = "noam.teyssier@arcinsistute.org" },
+    { name = "Abhinav Adduri", email = "abhinav.adduri@arcinstitute.org" },
+    { name = "Yusuf Roohani", email = "yusuf.roohani@arcinstitute.org" },
+    { name = "Noam Teyssier", email = "noam.teyssier@arcinstitute.org" },
 ]
 requires-python = ">=3.10,<3.13"
 dependencies = [

--- a/src/state_load/data_modules/perturbation_dataloader.py
+++ b/src/state_load/data_modules/perturbation_dataloader.py
@@ -686,18 +686,6 @@ class PerturbationDataModule(LightningDataModule):
             cell_types[cell_type] = fpath
         return cell_types
 
-    def _group_specs_by_dataset(
-        self, specs: List[TaskSpec]
-    ) -> Dict[str, List[TaskSpec]]:
-        """
-        Group a list of TaskSpecs by dataset name.
-        Return dict: {dataset_name -> [TaskSpec, TaskSpec, ...]}
-        """
-        dmap = {}
-        for spec in specs:
-            dmap.setdefault(spec.dataset, []).append(spec)
-        return dmap
-
     def _get_test_cell_types(
         self, dataset: str, test_map: Dict[str, List[TaskSpec]]
     ) -> Set[str]:

--- a/src/state_load/data_modules/samplers.py
+++ b/src/state_load/data_modules/samplers.py
@@ -144,8 +144,6 @@ class PerturbationBatchSampler(Sampler):
         if "use_batch" in self.__dict__ and self.use_batch:
             # If using batch, we need to use the batch codes instead of cell type codes.
             batch_codes = cache.batch_codes[indices]
-            # Also get batch codes if grouping by batch is desired.
-            batch_codes = cache.batch_codes[indices]
             dt = np.dtype(
                 [
                     ("batch", batch_codes.dtype),

--- a/src/state_load/data_modules/tasks.py
+++ b/src/state_load/data_modules/tasks.py
@@ -29,26 +29,22 @@ class TaskSpec:
 def parse_dataset_specs(specs: List[str]) -> List[TaskSpec]:
     """Parse dataset specifications into TaskSpec objects
 
-    Format: dataset[_celltype][,tasktype]
+    Format: ``dataset[:cell_type[:task_type]]``
     Examples:
-    - replogle
-    - replogle_jurkat:zeroshot
-    - sciplex_k562:fewshot
+    - ``replogle``
+    - ``replogle:jurkat:zeroshot``
+    - ``sciplex:k562:fewshot``
     """
     parsed_specs = []
 
     for spec in specs:
         parts = spec.split(":")
-        dataset_part = parts[0]
-        cell_type = parts[1] if len(parts) > 2 else None
+        dataset = parts[0]
+        cell_type = parts[1] if len(parts) > 1 else None
         task_type = TaskType.TRAINING  # Default
 
         if len(parts) > 2:
             task_type = TaskType[parts[2].upper()]
-
-        # Parse dataset and optional cell type
-        dataset_parts = dataset_part.split(":")
-        dataset = dataset_parts[0]
 
         parsed_specs.append(
             TaskSpec(dataset=dataset, cell_type=cell_type, task_type=task_type)


### PR DESCRIPTION
## Summary
- correct author email typos
- clarify and fix dataset specification parsing
- drop duplicate helper in `PerturbationDataModule`
- remove redundant line in sampler

## Testing
- `pytest -q` *(fails: command not found)*
- `ruff .` *(fails: unrecognized subcommand)*