### PR TITLE
updating the way gene names are fetched for group objects

### DIFF
--- a/src/cell_load/dataset/perturbation_dataset.py
+++ b/src/cell_load/dataset/perturbation_dataset.py
@@ -334,7 +334,10 @@ class PerturbationDataset(Dataset):
             return x.decode("utf-8") if isinstance(x, (bytes, bytearray)) else str(x)
 
         try:
-            if "var/gene_name/codes" in self.h5_file and "var/gene_name/categories" in self.h5_file:
+            if (
+                "var/gene_name/codes" in self.h5_file
+                and "var/gene_name/categories" in self.h5_file
+            ):
                 gene_codes = self.h5_file["var/gene_name/codes"][:]
                 gene_categories = self.h5_file["var/gene_name/categories"][:]
                 raw = gene_categories[gene_codes]


### PR DESCRIPTION
we were assuming gene_names was an array, but for some datasets, its a group. added a fix for this