### PR TITLE
Fix typos and minor bugs

### DIFF
--- a/src/cell_load/config.py
+++ b/src/cell_load/config.py
@@ -70,7 +70,6 @@ class ExperimentConfig:
             if key.startswith(f"{dataset}."):
                 celltype = key.split(".", 1)[1]
                 result[celltype] = pert_config
-                print(dataset, celltype, {k: len(v) for k, v in pert_config.items()})
         return result
 
     def validate(self) -> None:

--- a/src/cell_load/data_modules/perturbation_dataloader.py
+++ b/src/cell_load/data_modules/perturbation_dataloader.py
@@ -59,7 +59,7 @@ class PerturbationDataModule(LightningDataModule):
             num_workers: Num workers for PyTorch DataLoader
             few_shot_percent: Fraction of data to use for few-shot tasks
             random_seed: For reproducible splits & sampling
-            embed_key: Embedding key or matrix in the H5 file to use for feauturizing cells
+            embed_key: Embedding key or matrix in the H5 file to use for featurizing cells
             output_space: The output space for model predictions (gene or latent, which uses embed_key)
             basal_mapping_strategy: One of {"batch","random","nearest","ot"}
             n_basal_samples: Number of control cells to sample per perturbed cell

--- a/src/cell_load/dataset/_perturbation.py
+++ b/src/cell_load/dataset/_perturbation.py
@@ -456,8 +456,8 @@ class PerturbationDataset(Dataset):
         if has_ctrl_cell_counts:
             ctrl_cell_counts = torch.stack(ctrl_cell_counts_list)
 
-            is_discrete = suspected_discrete_torch(pert_cell_counts)
-            is_log = suspected_log_torch(pert_cell_counts)
+            is_discrete = suspected_discrete_torch(ctrl_cell_counts)
+            is_log = suspected_log_torch(ctrl_cell_counts)
             already_logged = (not is_discrete) and is_log
 
             if already_logged:  # counts are already log transformed

--- a/src/cell_load/utils/data_utils.py
+++ b/src/cell_load/utils/data_utils.py
@@ -282,8 +282,7 @@ def is_on_target_knockdown(
         return False
 
     if target_gene not in adata.var_names:
-        print(f"Gene {target_gene!r} not found in `adata.var_names`.")
-        return 1
+        raise KeyError(f"Gene {target_gene!r} not found in `adata.var_names`.")
 
     gene_idx = adata.var_names.get_loc(target_gene)
     X = adata.layers[layer] if layer is not None else adata.X
@@ -396,7 +395,9 @@ def filter_on_target_knockdown(
     return adata_[keep_mask]
 
 
-def set_var_index_to_col(adata: anndata.AnnData, col: str = "col", copy=True) -> None:
+def set_var_index_to_col(
+    adata: anndata.AnnData, col: str = "col", copy: bool = True
+) -> anndata.AnnData:
     """
     Set `adata.var` index to the values in the specified column, allowing non-unique indices.
 
@@ -412,6 +413,9 @@ def set_var_index_to_col(adata: anndata.AnnData, col: str = "col", copy=True) ->
     KeyError
         If the specified column does not exist in `adata.var`.
     """
+    if copy:
+        adata = adata.copy()
+
     if col not in adata.var.columns:
         raise KeyError(f"Column {col!r} not found in adata.var.")
 


### PR DESCRIPTION
## Summary
- correct a spelling mistake in `PerturbationDataModule` docs
- remove stray print from `ExperimentConfig`
- fix wrong variable used when processing control counts
- raise `KeyError` when gene not found in `is_on_target_knockdown`
- document and implement copy flag in `set_var_index_to_col`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68499a7c92c48329a64a4d9eeb02eb58