### PR TITLE
fixes bug that requires X_hvg even when modeling with .X

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-load"
-version = "0.7.2"
+version = "0.7.3"
 description = "Dataloaders for training models on huge single-cell datasets"
 readme = "README.md"
 authors = [

--- a/src/cell_load/dataset/_perturbation.py
+++ b/src/cell_load/dataset/_perturbation.py
@@ -560,7 +560,10 @@ class PerturbationDataset(Dataset):
 
     def get_num_hvgs(self) -> int:
         """Return the number of highly variable genes in the obsm matrix."""
-        return self.h5_file["obsm/X_hvg"].shape[1]
+        try:
+            return self.h5_file["obsm/X_hvg"].shape[1]
+        except:
+            return 0
 
     def _get_num_cells(self) -> int:
         """Return the total number of cells in the file."""


### PR DESCRIPTION
the current code requires that a .obsm['X_hvg'] exists, even when modeling with .X (e.g. when embed key is null and output space is all)