### PR TITLE
Fix CSR data types in _perturbation.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-load"
-version = "0.7.5"
+version = "0.7.6"
 description = "Dataloaders for training models on huge single-cell datasets"
 readme = "README.md"
 authors = [

--- a/src/cell_load/dataset/_perturbation.py
+++ b/src/cell_load/dataset/_perturbation.py
@@ -309,7 +309,7 @@ class PerturbationDataset(Dataset):
                 self.h5_file["/X/indices"][start_ptr:end_ptr], dtype=torch.long
             )
             counts = torch.sparse_csr_tensor(
-                torch.tensor([0], dtype=torch.float32),
+                torch.tensor([0], dtype=torch.long),
                 sub_indices,
                 sub_data,
                 (1, self.n_genes),


### PR DESCRIPTION
Using float32 in this field causes a RuntimeError: "convert_indices_from_csr_to_coo_cpu" not implemented for 'Float'.

This seems to be a bug introduced in [this commit](https://github.com/ArcInstitute/cell-load/commit/395a98740fb532f867499168ff60cca7ba62978c). 

To reproduce this error, run the [Google Colab](https://colab.research.google.com/drive/1QKOtYP7bMpdgDJEipDxaJqOchv7oQ-_l) notebook for the virtual cell challenge. 