### PR TITLE
Fix: Allow the user to select whether to drop the last sentence

### DIFF
--- a/src/cell_load/data_modules/perturbation_dataloader.py
+++ b/src/cell_load/data_modules/perturbation_dataloader.py
@@ -49,6 +49,7 @@ class PerturbationDataModule(LightningDataModule):
         n_basal_samples: int = 1,
         should_yield_control_cells: bool = True,
         cell_sentence_len: int = 512,
+        drop_last: bool = False,
         **kwargs,  # missing perturbation_features_file  and store_raw_basal for backwards compatibility
     ):
         """
@@ -66,6 +67,7 @@ class PerturbationDataModule(LightningDataModule):
             output_space: The output space for model predictions (gene or latent, which uses embed_key)
             basal_mapping_strategy: One of {"batch","random","nearest","ot"}
             n_basal_samples: Number of control cells to sample per perturbed cell
+            drop_last: Whether to drop the last sentence set if it is smaller than cell_sentence_len
         """
         super().__init__()
 
@@ -79,6 +81,7 @@ class PerturbationDataModule(LightningDataModule):
         self.num_workers = num_workers
         self.random_seed = random_seed
         self.rng = np.random.default_rng(random_seed)
+        self.drop_last = drop_last
 
         # H5 field names
         self.pert_col = pert_col
@@ -358,7 +361,7 @@ class PerturbationDataModule(LightningDataModule):
         sampler = PerturbationBatchSampler(
             dataset=ds,
             batch_size=batch_size,
-            drop_last=False,
+            drop_last=self.drop_last,
             cell_sentence_len=self.cell_sentence_len,
             test=test,
             use_batch=use_batch,


### PR DESCRIPTION
This PR adds a configurable `drop_last` parameter to the `PerturbationDataModule` class, providing users with control over whether incomplete sentence sets should be dropped during data loading.

## Changes

**New parameter**: Added `drop_last: bool = False` parameter to `PerturbationDataModule.__init__()`
**Documentation**: Updated docstring to describe the new parameter's behavior
**Implementation**: The parameter now controls the `drop_last` behavior in `PerturbationBatchSampler` instead of being hardcoded to False

## Behavior
When `drop_last=True`, sentence sets that are smaller than `cell_sentence_len` will be dropped during data loading. 

**The default value remains `False` to preserve backward compatibility**, meaning incomplete sentence sets will be kept by default.

**This PR passes all existing unit tests**